### PR TITLE
persist language setting after app restart

### DIFF
--- a/src/renderer/src/i18n/index.ts
+++ b/src/renderer/src/i18n/index.ts
@@ -27,7 +27,7 @@ i18n
     detection: {
       order: ['localStorage', 'navigator'],
       caches: ['localStorage'],
-      lookupLocalStorage: 'chat2api-settings',
+      lookupLocalStorage: 'i18nextLng',
       convertDetectedLanguage: (lng: string) => {
         if (lng.includes('zh')) return 'zh-CN'
         if (lng.includes('en')) return 'en-US'

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -67,9 +67,14 @@ export const useSettingsStore = create<SettingsState>()(
         }
       },
       language: 'en-US',
-      setLanguage: (language) => {
+      setLanguage: async (language) => {
         set({ language })
-        i18n.changeLanguage(language)
+        await i18n.changeLanguage(language)
+        try {
+          await window.electronAPI.config.update({ language: language })
+        } catch (error) {
+          console.error('Failed to update language:', error)
+        }
       },
       autoStart: false,
       setAutoStart: async (enabled) => {
@@ -129,6 +134,7 @@ export const useSettingsStore = create<SettingsState>()(
             autoStart: config.autoStart,
             autoStartProxy: config.autoStartProxy,
             oauthProxyMode: config.oauthProxyMode || 'system',
+            language: config.language || 'en-US',
           })
         } catch (error) {
           console.error('Failed to fetch config:', error)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,7 @@ export interface AppConfig {
   oauthProxyMode: 'system' | 'none'
   sessionConfig: SessionConfig
   toolPromptConfig: ToolPromptConfig
+  language: 'zh-CN' | 'en-US'
 }
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'


### PR DESCRIPTION
The language preference  was not correctly persisted after the application restarts. The observed behavior was:
1. Switch language → UI updates correctly (first time works).
2. Restart the app → UI still shows the previously selected language, but the setting in settings page has reverted to default.
3. Open the settings page and then restart again → both UI language and the displayed setting revert to default.