### PR TITLE
fix: resolve TS6305 error for shared types build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@shared/*": ["./src/shared/*"]
     }
   },
-  "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx", "src/shared/**/*.ts"],
+  "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- Remove `src/shared/**/*.ts` from root `tsconfig.json` include to fix TS6305 build error
- Shared types are already resolved via project reference in `tsconfig.node.json`

## Test plan
- [x] `npx tsc --noEmit` shows 0 TS6305 errors

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)