### PR TITLE
fix: resolve TS6305 and TS6133 compilation errors

### DIFF
--- a/src/renderer/src/components/models/ModelEditor.tsx
+++ b/src/renderer/src/components/models/ModelEditor.tsx
@@ -200,7 +200,7 @@ export function ModelEditor({
     }
   }
 
-  const renderModelTable = (modelList: EffectiveModel[], isCustom: boolean) => {
+  const renderModelTable = (modelList: EffectiveModel[], _isCustom: boolean) => {
     if (modelList.length === 0) {
       return (
         <div className="text-center py-8 text-muted-foreground border rounded-lg">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,5 @@
       "@shared/*": ["./src/shared/*"]
     }
   },
-  "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx", "src/shared/**/*.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx", "src/shared/**/*.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Remove `composite: true` from `tsconfig.node.json` and `references` from root `tsconfig.json` to fix TS6305 without breaking `BuiltinProviderConfig` type resolution
- Fix unused `isCustom` parameter in `ModelEditor.tsx` (TS6133)

## Root Cause
The previous approach (removing shared types from root include) broke `BuiltinProviderConfig extends Provider` type resolution, since `electron.d.ts` imports `Provider` from `shared/types`. Removing `composite` eliminates the declaration emit conflict at its source.

## Test plan
- [x] `npx tsc --noEmit` shows 0 errors (0 TS6305, 0 BuiltinProviderConfig, 0 TS6133)

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)