### PR TITLE
fix: wire credential encryption toggle to backend

### DIFF
--- a/src/main/store/store.ts
+++ b/src/main/store/store.ts
@@ -375,6 +375,10 @@ class StoreManager {
     try {
       console.log('[Store] encryptData input length:', data.length, 'content:', data.substring(0, 20) + '...')
       if (safeStorage.isEncryptionAvailable()) {
+        if (!this.getConfig().credentialEncryption) {
+          console.log('[Store] Credential encryption disabled, returning plaintext')
+          return data
+        }
         // Create new Buffer to store encryption result
         const encrypted = Buffer.from(safeStorage.encryptString(data))
         const result = encrypted.toString('base64')

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -213,6 +213,8 @@ export interface AppConfig {
   managementApi: ManagementApiConfig
   /** Context management configuration */
   contextManagement: ContextManagementConfig
+  /** Whether to encrypt credentials in data.json */
+  credentialEncryption: boolean
 }
 
 /**
@@ -748,6 +750,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   toolPromptConfig: DEFAULT_TOOL_PROMPT_CONFIG,
   managementApi: DEFAULT_MANAGEMENT_API_CONFIG,
   contextManagement: DEFAULT_CONTEXT_MANAGEMENT_CONFIG,
+  credentialEncryption: true,
 }
 
 /**

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -107,7 +107,14 @@ export const useSettingsStore = create<SettingsState>()(
       maxLogs: 10000,
       setMaxLogs: (count) => set({ maxLogs: count }),
       credentialEncryption: true,
-      setCredentialEncryption: (enabled) => set({ credentialEncryption: enabled }),
+      setCredentialEncryption: async (enabled) => {
+        set({ credentialEncryption: enabled })
+        try {
+          await window.electronAPI.config.update({ credentialEncryption: enabled })
+        } catch (error) {
+          console.error('Failed to update credentialEncryption:', error)
+        }
+      },
       logDesensitization: true,
       setLogDesensitization: (enabled) => set({ logDesensitization: enabled }),
       config: null,
@@ -144,6 +151,7 @@ export const useSettingsStore = create<SettingsState>()(
             autoStartProxy: config.autoStartProxy,
             oauthProxyMode: config.oauthProxyMode || 'system',
             language: config.language || 'en-US',
+            credentialEncryption: config.credentialEncryption ?? true,
           })
         } catch (error) {
           console.error('Failed to fetch config:', error)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -103,6 +103,7 @@ export interface AppConfig {
   sessionConfig: SessionConfig
   toolPromptConfig: ToolPromptConfig
   language: 'zh-CN' | 'en-US'
+  credentialEncryption: boolean
 }
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'


### PR DESCRIPTION
## Summary
- The "凭证加密" (credential encryption) switch in Security Settings was a dead toggle — its state was only stored in the renderer Zustand store and never communicated to the main process
- `encryptData()` always encrypted credentials when `safeStorage` was available, completely ignoring the UI toggle
- This PR adds `credentialEncryption` to the AppConfig type (both shared and backend), wires the toggle through IPC, and makes `encryptData()` respect the setting

## Changes
- **`src/shared/types.ts`**: Add `credentialEncryption: boolean` to AppConfig
- **`src/main/store/types.ts`**: Add field to AppConfig + DEFAULT_CONFIG (defaults to `true`)
- **`src/main/store/store.ts`**: `encryptData()` checks `this.getConfig().credentialEncryption` before encrypting; returns plaintext when disabled
- **`src/renderer/src/stores/settingsStore.ts`**: `setCredentialEncryption` now calls `window.electronAPI.config.update()` via IPC; `fetchConfig()` syncs the value from backend on startup

## Backward Compatibility
- `normalizeConfig` uses `{ ...DEFAULT_CONFIG, ...config }`, so old configs without the field default to `true` (encryption on — matching old behavior)
- `decryptData()` is unchanged — its existing try/catch already handles both encrypted and plaintext data

## Test Plan
- [ ] Toggle "凭证加密" OFF → save account → check data.json: credentials should be plaintext
- [ ] Toggle "凭证加密" ON → save account → check data.json: credentials should be encrypted (base64)
- [ ] Restart app → toggle state should persist correctly
- [ ] Old encrypted credentials still work after toggling OFF

Closes #91

## 需要人工测试
此 PR 涉及 Electron safeStorage 加密和 IPC 通信，**必须人工测试**后才能合并，请勿仅依赖 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)