### PR TITLE
docs: mention Zoo Code as the Roo Code community successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <p align="center">
-  Chat2API enables zero-cost access to leading AI models by leveraging official web UIs. It supports providers such as DeepSeek, GLM, Kimi, MiniMax, Qwen, and Z.ai, and seamlessly integrates with tools like openlcaw, Cline, and Roo-Code — making any OpenAI-compatible client work out of the box.
+  Chat2API enables zero-cost access to leading AI models by leveraging official web UIs. It supports providers such as DeepSeek, GLM, Kimi, MiniMax, Qwen, and Z.ai, and seamlessly integrates with tools like openlcaw, Cline, Roo-Code, and its community successor [Zoo Code](https://zoocode.dev/) — making any OpenAI-compatible client work out of the box.
 </p>
 
 ![Product Preview](docs/screenshots/preview.png)


### PR DESCRIPTION
Roo Code (`RooCodeInc/Roo-Code`) was archived / shut down on May 15, 2026 and is now
read-only. Its own repo notes the community successor here:
https://github.com/RooCodeInc/Roo-Code#disclaimer

Zoo Code is the community-maintained fork that continues where Roo Code left off:
- Site: https://zoocode.dev/
- Source: https://github.com/Zoo-Code-Org/Zoo-Code/

This PR adds a Zoo Code reference alongside the existing Roo Code mention in the README so
readers looking for a maintained alternative can find it.
